### PR TITLE
Add messaging inbox with SQL storage

### DIFF
--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -52,6 +52,7 @@
         <!-- Sidebar menu items -->
         <RadzenPanelMenu DisplayStyle="@(sidebarExpanded ? MenuItemDisplayStyle.IconAndText : MenuItemDisplayStyle.Icon)" ShowArrow="false" class="menu-items">
             <RadzenPanelMenuItem Text="Home" Path="" Icon="Home"/>
+            <RadzenPanelMenuItem Text="Messages" Path="messages" Icon="mail" />
         </RadzenPanelMenu>
 
         <!-- Footer section of the sidebar -->

--- a/Client/Pages/Messages.razor
+++ b/Client/Pages/Messages.razor
@@ -1,0 +1,60 @@
+@page "/messages"
+
+<PageTitle>Messages</PageTitle>
+
+@if (messages == null)
+{
+    <RadzenProgressBarCircular Mode="ProgressBarMode.Indeterminate" Style="width:40px;height:40px" />
+}
+else
+{
+    <RadzenRow>
+        <RadzenColumn Size="12" SizeMD="4">
+            <RadzenTemplateForm Data="@newMessage" TItem="MessageModel" Submit="SendAsync">
+                <RadzenFieldset Legend="Send Message">
+                    <RadzenLabel Text="Recipient" />
+                    <RadzenTextBox @bind-Value="newMessage.Recipient" Style="width:100%" />
+                    <RadzenLabel Text="Message" />
+                    <RadzenTextArea @bind-Value="newMessage.Content" Style="width:100%" />
+                    <RadzenButton ButtonType="ButtonType.Submit" Text="Send" Style="margin-top:10px" />
+                </RadzenFieldset>
+            </RadzenTemplateForm>
+        </RadzenColumn>
+        <RadzenColumn Size="12" SizeMD="8">
+            <RadzenDataGrid Data="@messages" TItem="MessageModel" RowHover="true">
+                <Columns>
+                    <RadzenDataGridColumn TItem="MessageModel" Property="Timestamp" Title="Time" />
+                    <RadzenDataGridColumn TItem="MessageModel" Property="Direction" Title="Direction" />
+                    <RadzenDataGridColumn TItem="MessageModel" Property="Sender" Title="From" />
+                    <RadzenDataGridColumn TItem="MessageModel" Property="Recipient" Title="To" />
+                    <RadzenDataGridColumn TItem="MessageModel" Property="Content" Title="Message" />
+                </Columns>
+            </RadzenDataGrid>
+        </RadzenColumn>
+    </RadzenRow>
+}
+
+@code {
+    private List<MessageModel>? messages;
+    private MessageModel newMessage = new MessageModel();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        var user = await CookieHelper.LoginStatus();
+        newMessage.UserName = user;
+        messages = await MessageService.GetMessages(user);
+    }
+
+    private async Task SendAsync()
+    {
+        newMessage.UserName = await CookieHelper.LoginStatus();
+        await MessageService.SendMessage(newMessage);
+        newMessage = new MessageModel();
+        await LoadAsync();
+    }
+}

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddScoped(sp =>
 
 
 builder.Services.AddScoped<IUserService, UserServiceProxy>();
+builder.Services.AddScoped<IMessageService, MessageServiceProxy>();
 
 builder.Services.AddScoped<CookieHelper>();
 

--- a/Client/Services/MessageServiceProxy.cs
+++ b/Client/Services/MessageServiceProxy.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using NDAProcesses.Shared.Models;
+using NDAProcesses.Shared.Services;
+
+namespace NDAProcesses.Client.Services
+{
+    public class MessageServiceProxy : IMessageService
+    {
+        private readonly HttpClient _httpClient;
+        public MessageServiceProxy(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<List<MessageModel>> GetMessages(string userName)
+        {
+            return await _httpClient.GetFromJsonAsync<List<MessageModel>>($"api/messages/{userName}")
+                ?? new List<MessageModel>();
+        }
+
+        public async Task SendMessage(MessageModel message)
+        {
+            await _httpClient.PostAsJsonAsync("api/messages/send", message);
+        }
+    }
+}

--- a/Client/_Imports.razor
+++ b/Client/_Imports.razor
@@ -22,3 +22,4 @@
 @inject NotificationService NotificationService
 @inject CookieHelper CookieHelper
 @inject IUserService UserService
+@inject IMessageService MessageService

--- a/NdaProcesses.Shared/Models/MessageModel.cs
+++ b/NdaProcesses.Shared/Models/MessageModel.cs
@@ -1,0 +1,18 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace NDAProcesses.Shared.Models
+{
+    public class MessageModel
+    {
+        [Key]
+        public int Id { get; set; }
+        public string? ExternalId { get; set; }
+        public string? UserName { get; set; }
+        public string? Sender { get; set; }
+        public string Recipient { get; set; }
+        public string Content { get; set; }
+        public DateTime Timestamp { get; set; }
+        public string Direction { get; set; }
+    }
+}

--- a/NdaProcesses.Shared/Services/IMessageService.cs
+++ b/NdaProcesses.Shared/Services/IMessageService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NDAProcesses.Shared.Models;
+
+namespace NDAProcesses.Shared.Services
+{
+    public interface IMessageService
+    {
+        Task<List<MessageModel>> GetMessages(string userName);
+        Task SendMessage(MessageModel message);
+    }
+}

--- a/Server/Controllers/MessageController.cs
+++ b/Server/Controllers/MessageController.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using NDAProcesses.Shared.Models;
+using NDAProcesses.Shared.Services;
+
+namespace NDAProcesses.Server.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class MessagesController : ControllerBase
+    {
+        private readonly IMessageService _messageService;
+        public MessagesController(IMessageService messageService)
+        {
+            _messageService = messageService;
+        }
+
+        [HttpGet("{userName}")]
+        public async Task<IEnumerable<MessageModel>> Get(string userName)
+        {
+            return await _messageService.GetMessages(userName);
+        }
+
+        [HttpPost("send")]
+        public async Task<IActionResult> Send([FromBody] MessageModel message)
+        {
+            await _messageService.SendMessage(message);
+            return Ok();
+        }
+    }
+}

--- a/Server/Data/MessagingContext.cs
+++ b/Server/Data/MessagingContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using NDAProcesses.Shared.Models;
+
+namespace NDAProcesses.Server.Data
+{
+    public class MessagingContext : DbContext
+    {
+        public MessagingContext(DbContextOptions<MessagingContext> options) : base(options)
+        {
+        }
+
+        public DbSet<MessageModel> Messages => Set<MessageModel>();
+    }
+}

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -3,6 +3,7 @@ using NDAProcesses.Server.Components;
 using NDAProcesses.Client.Services;
 using NDAProcesses.Shared.Services;
 using NDAProcesses.Server.Services;
+using NDAProcesses.Server.Data;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -26,12 +27,21 @@ builder.Services.AddCors(options =>
 
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<CookieHelper>();
+builder.Services.AddScoped<IMessageService, MessageService>();
+builder.Services.AddDbContext<MessagingContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
 
 builder.Services.AddControllers();
 builder.Services.AddRadzenComponents();
 builder.Services.AddHttpClient();
 builder.Services.AddHttpContextAccessor();
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<MessagingContext>();
+    db.Database.EnsureCreated();
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/Server/Services/MessageService.cs
+++ b/Server/Services/MessageService.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using NDAProcesses.Server.Data;
+using NDAProcesses.Shared.Models;
+using NDAProcesses.Shared.Services;
+
+namespace NDAProcesses.Server.Services
+{
+    public class MessageService : IMessageService
+    {
+        private readonly MessagingContext _db;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IConfiguration _config;
+        private readonly string _baseUrl;
+        private readonly string _apiKey;
+        private readonly string _deviceId;
+
+        public MessageService(MessagingContext db, IHttpClientFactory httpClientFactory, IConfiguration config)
+        {
+            _db = db;
+            _httpClientFactory = httpClientFactory;
+            _config = config;
+            _baseUrl = _config["TextBee:BaseUrl"] ?? "";
+            _apiKey = _config["TextBee:ApiKey"] ?? "";
+            _deviceId = _config["TextBee:DeviceId"] ?? "";
+        }
+
+        public async Task SendMessage(MessageModel message)
+        {
+            var client = _httpClientFactory.CreateClient();
+            client.DefaultRequestHeaders.Add("x-api-key", _apiKey);
+            var url = $"{_baseUrl}/gateway/devices/{_deviceId}/send-sms";
+            var payload = new { recipients = new[] { message.Recipient }, message = message.Content };
+            var response = await client.PostAsJsonAsync(url, payload);
+            if (response.IsSuccessStatusCode)
+            {
+                try
+                {
+                    var doc = await response.Content.ReadFromJsonAsync<JsonElement>();
+                    if (doc.TryGetProperty("id", out var idProp))
+                    {
+                        message.ExternalId = idProp.GetString();
+                    }
+                }
+                catch { }
+            }
+            message.Timestamp = DateTime.UtcNow;
+            message.Direction = "Sent";
+            _db.Messages.Add(message);
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task<List<MessageModel>> GetMessages(string userName)
+        {
+            await SyncInboxAsync();
+            return await _db.Messages
+                .Where(m => m.UserName == userName || m.Direction == "Received")
+                .OrderByDescending(m => m.Timestamp)
+                .ToListAsync();
+        }
+
+        private async Task SyncInboxAsync()
+        {
+            var client = _httpClientFactory.CreateClient();
+            client.DefaultRequestHeaders.Add("x-api-key", _apiKey);
+            var url = $"{_baseUrl}/gateway/devices/{_deviceId}/messages";
+            var response = await client.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                return;
+            }
+            using var doc = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+            IEnumerable<JsonElement> messages;
+            var root = doc.RootElement;
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                messages = root.EnumerateArray();
+            }
+            else if (root.TryGetProperty("messages", out var arr) && arr.ValueKind == JsonValueKind.Array)
+            {
+                messages = arr.EnumerateArray();
+            }
+            else
+            {
+                messages = Enumerable.Empty<JsonElement>();
+            }
+
+            foreach (var m in messages)
+            {
+                var direction = GetString(m, "direction").ToLower();
+                if (!direction.Contains("received"))
+                {
+                    continue;
+                }
+                var id = GetAnyId(m);
+                if (id != null && _db.Messages.Any(x => x.ExternalId == id))
+                {
+                    continue;
+                }
+                var sender = GetString(m, "from");
+                var recipient = GetString(m, "to");
+                var body = GetString(m, "message");
+                if (string.IsNullOrEmpty(body))
+                {
+                    body = GetString(m, "text");
+                }
+                var tsString = GetString(m, "timestamp");
+                DateTime.TryParse(tsString, out var ts);
+                var model = new MessageModel
+                {
+                    ExternalId = id,
+                    Sender = sender,
+                    Recipient = recipient,
+                    Content = body,
+                    Timestamp = ts == DateTime.MinValue ? DateTime.UtcNow : ts.ToUniversalTime(),
+                    Direction = "Received"
+                };
+                _db.Messages.Add(model);
+            }
+            await _db.SaveChangesAsync();
+        }
+
+        private static string GetString(JsonElement element, string name)
+        {
+            return element.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String ? prop.GetString() ?? string.Empty : string.Empty;
+        }
+
+        private static string? GetAnyId(JsonElement element)
+        {
+            foreach (var name in new[] { "id", "message_id", "_id", "uuid" })
+            {
+                var val = GetString(element, name);
+                if (!string.IsNullOrEmpty(val))
+                {
+                    return val;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -11,4 +11,13 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "ConnectionStrings": {
+    "Default": "Server=10.201.50.70\\NDASHAFTDB;Initial Catalog=NDA_MS_FORM;User ID=sa;Password=NDA_Admin;TrustServerCertificate=True;"
+  },
+  "TextBee": {
+    "BaseUrl": "https://api.textbee.dev/api/v1",
+    "ApiKey": "f8a41718-e4c9-4567-b24c-eb9e33dd106d",
+    "DeviceId": "68bf24d3c3eec74784421f4c"
+  }
 }


### PR DESCRIPTION
## Summary
- add message model and service contract
- store messages in SQL and integrate with TextBee API
- build client inbox page with sending support

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c15f9d059883299a2b81e38641d39f