### PR TITLE
Poll TextBee API for incoming messages

### DIFF
--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -153,7 +153,7 @@
         waitingforuserload = true; // Mark the user data as loaded
     }
 
-    private async Task NavigateToMessages(RadzenPanelMenuItemEventArgs args)
+    private async Task NavigateToMessages()
     {
         if (!string.IsNullOrEmpty(userId))
         {

--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 <RadzenComponents />
+@inject IMessageService MessageService
 
 <!-- Define the overall layout of the page using RadzenLayout -->
 <RadzenLayout style="grid-template-areas: 'rz-sidebar rz-header' 'rz-sidebar rz-body';" class="rz-responsive-layout">
@@ -52,7 +53,7 @@
         <!-- Sidebar menu items -->
         <RadzenPanelMenu DisplayStyle="@(sidebarExpanded ? MenuItemDisplayStyle.IconAndText : MenuItemDisplayStyle.Icon)" ShowArrow="false" class="menu-items">
             <RadzenPanelMenuItem Text="Home" Path="" Icon="Home"/>
-            <RadzenPanelMenuItem Text="Messages" Path="messages" Icon="mail"/>
+            <RadzenPanelMenuItem Text="Messages" Icon="mail" Click="@NavigateToMessages"/>
             <RadzenPanelMenuItem Text="Contacts" Path="contacts" Icon="contacts"/>
         </RadzenPanelMenu>
 
@@ -80,6 +81,7 @@
     private string sidebarToggleIcon => sidebarExpanded ? "keyboard_arrow_left" : "keyboard_arrow_right";
     private UserModel ValidUser;
     private string username;
+    private string userId;
     private bool waitingforuserload = false;
     private string dynamicClass = "rz-mb-0";
     private string dynamicImageSize = "width: 96px; height: 48px;";
@@ -138,7 +140,7 @@
     // Fetches the username of the currently logged-in user from the cookie
     private async Task FetchUsernameAsync()
     {
-        string userId = await CookieHelper.LoginStatus();
+        userId = await CookieHelper.LoginStatus();
         if (string.IsNullOrEmpty(userId))
         {
             username = null;
@@ -149,5 +151,17 @@
             username = ValidUser.DisplayName;
         }
         waitingforuserload = true; // Mark the user data as loaded
+    }
+
+    private async Task NavigateToMessages(RadzenPanelMenuItemEventArgs args)
+    {
+        if (!string.IsNullOrEmpty(userId))
+        {
+            // Preload contacts and messages before navigation to reduce perceived load time
+            var contactsTask = MessageService.GetContacts();
+            var messagesTask = MessageService.GetMessages(userId);
+            await Task.WhenAll(contactsTask, messagesTask);
+        }
+        NavigationManager.NavigateTo("messages");
     }
 }

--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -52,6 +52,8 @@
         <!-- Sidebar menu items -->
         <RadzenPanelMenu DisplayStyle="@(sidebarExpanded ? MenuItemDisplayStyle.IconAndText : MenuItemDisplayStyle.Icon)" ShowArrow="false" class="menu-items">
             <RadzenPanelMenuItem Text="Home" Path="" Icon="Home"/>
+            <RadzenPanelMenuItem Text="Messages" Path="messages" Icon="mail"/>
+            <RadzenPanelMenuItem Text="Contacts" Path="contacts" Icon="contacts"/>
         </RadzenPanelMenu>
 
         <!-- Footer section of the sidebar -->

--- a/Client/Pages/Contacts.razor
+++ b/Client/Pages/Contacts.razor
@@ -33,8 +33,9 @@ else
                     @("+1" + contact.PhoneNumber)
                 </Template>
                 <EditTemplate Context="contact">
-                    <RadzenTextBox @bind-Value="contact.PhoneNumber" Name="Phone" Style="width:100%" InputAttributes="@(new Dictionary<string,object>{{"maxlength","10"},{"pattern","[0-9]*"},{"inputmode","numeric"}})" />
-                    <RadzenRegularExpressionValidator Component="Phone" Pattern="^[0-9]{10}$" Text="Phone must be 10 digits" Popup="true" />
+                    <RadzenMaskedTextBox @bind-Value="contact.PhoneNumber" Name="Phone" Mask="+1 (000) 000-0000" Style="width:100%" />
+                    <RadzenRequiredValidator Component="Phone" Text="Phone is required" Popup="true" />
+                    <RadzenRegularExpressionValidator Component="Phone" Pattern="^\\+1 \\([0-9]{3}\\) [0-9]{3}-[0-9]{4}$" Text="Phone must be 10 digits" Popup="true" />
                 </EditTemplate>
             </RadzenDataGridColumn>
             <RadzenDataGridColumn Property="Notes" Title="Notes">
@@ -150,6 +151,10 @@ else
         try
         {
             var digits = new string((contact.PhoneNumber ?? string.Empty).Where(char.IsDigit).ToArray());
+            if (digits.Length == 11 && digits.StartsWith("1"))
+            {
+                digits = digits[1..];
+            }
             if (digits.Length != 10)
             {
                 NotificationService.Notify(NotificationSeverity.Error, "Error", "Phone number must be 10 digits");

--- a/Client/Pages/Contacts.razor
+++ b/Client/Pages/Contacts.razor
@@ -33,9 +33,8 @@ else
                     @("+1" + contact.PhoneNumber)
                 </Template>
                 <EditTemplate Context="contact">
-                    <RadzenTextBox @bind-Value="contact.PhoneNumber" Name="Phone" Mask="+1 (000) 000-0000" Style="width:100%" />
+                    <RadzenMaskedTextBox @bind-Value="contact.PhoneNumber" Name="Phone" Mask="(000) 000-0000" Style="width:100%" />
                     <RadzenRequiredValidator Component="Phone" Text="Phone is required" Popup="true" />
-                    <RadzenRegularExpressionValidator Component="Phone" Pattern="^\\+1 \\([0-9]{3}\\) [0-9]{3}-[0-9]{4}$" Text="Phone must be 10 digits" Popup="true" />
                 </EditTemplate>
             </RadzenDataGridColumn>
             <RadzenDataGridColumn Property="Notes" Title="Notes">
@@ -138,15 +137,22 @@ else
 
     async Task OnUpdateRow(ContactModel contact)
     {
-        await SaveContact(contact);
+        if (!await SaveContact(contact))
+        {
+            await grid!.EditRow(contact);
+        }
     }
 
     async Task OnCreateRow(ContactModel contact)
     {
-        await SaveContact(contact);
+        if (!await SaveContact(contact))
+        {
+            contacts.Remove(contact);
+            await grid!.CancelEditRow(contact);
+        }
     }
 
-    async Task SaveContact(ContactModel contact)
+    async Task<bool> SaveContact(ContactModel contact)
     {
         try
         {
@@ -158,7 +164,7 @@ else
             if (digits.Length != 10)
             {
                 NotificationService.Notify(NotificationSeverity.Error, "Error", "Phone number must be 10 digits");
-                return;
+                return false;
             }
             var toSave = new ContactModel
             {
@@ -170,10 +176,12 @@ else
             await MessageService.SaveContact(toSave);
             contacts = (await LoadContacts()).ToList();
             NotificationService.Notify(NotificationSeverity.Success, "Contact saved");
+            return true;
         }
         catch (Exception ex)
         {
             NotificationService.Notify(NotificationSeverity.Error, "Error", ex.Message);
         }
+        return false;
     }
 }

--- a/Client/Pages/Contacts.razor
+++ b/Client/Pages/Contacts.razor
@@ -33,7 +33,7 @@ else
                     @("+1" + contact.PhoneNumber)
                 </Template>
                 <EditTemplate Context="contact">
-                    <RadzenMaskedTextBox @bind-Value="contact.PhoneNumber" Name="Phone" Mask="(000) 000-0000" Style="width:100%" />
+                    <RadzenMask @bind-Value="contact.PhoneNumber" Name="Phone" Mask="(000) 000-0000" Style="width:100%" />
                     <RadzenRequiredValidator Component="Phone" Text="Phone is required" Popup="true" />
                 </EditTemplate>
             </RadzenDataGridColumn>
@@ -148,7 +148,7 @@ else
         if (!await SaveContact(contact))
         {
             contacts.Remove(contact);
-            await grid!.CancelEditRow(contact);
+            grid!.CancelEditRow(contact);
         }
     }
 

--- a/Client/Pages/Contacts.razor
+++ b/Client/Pages/Contacts.razor
@@ -33,7 +33,7 @@ else
                     @("+1" + contact.PhoneNumber)
                 </Template>
                 <EditTemplate Context="contact">
-                    <RadzenMaskedTextBox @bind-Value="contact.PhoneNumber" Name="Phone" Mask="+1 (000) 000-0000" Style="width:100%" />
+                    <RadzenTextBox @bind-Value="contact.PhoneNumber" Name="Phone" Mask="+1 (000) 000-0000" Style="width:100%" />
                     <RadzenRequiredValidator Component="Phone" Text="Phone is required" Popup="true" />
                     <RadzenRegularExpressionValidator Component="Phone" Pattern="^\\+1 \\([0-9]{3}\\) [0-9]{3}-[0-9]{4}$" Text="Phone must be 10 digits" Popup="true" />
                 </EditTemplate>

--- a/Client/Pages/Contacts.razor
+++ b/Client/Pages/Contacts.razor
@@ -1,0 +1,174 @@
+@page "/contacts"
+@using Radzen
+@using System.Linq
+@inject CookieHelper CookieHelper
+@inject NavigationManager NavigationManager
+@inject IMessageService MessageService
+@inject NotificationService NotificationService
+@inject DialogService DialogService
+
+<PageTitle>Contacts</PageTitle>
+
+@if (!isLoaded)
+{
+    <p>Loading...</p>
+}
+else if (string.IsNullOrEmpty(userName))
+{
+    <div class="alert alert-warning">Please login to manage contacts.</div>
+}
+else
+{
+    <RadzenButton Text="Add Contact" Icon="add_circle" Click="@InsertRow" Style="margin-bottom:10px" Disabled="@isInserting" />
+    <RadzenDataGrid @ref="grid" Data="@contacts" TItem="ContactModel" EditMode="DataGridEditMode.Single" RowUpdate="@OnUpdateRow" RowCreate="@OnCreateRow" AllowPaging="true" PageSize="10" AllowFiltering="true" AllowSorting="true" FilterMode="FilterMode.Advanced">
+        <Columns>
+            <RadzenDataGridColumn Property="Name" Title="Name">
+                <EditTemplate Context="contact">
+                    <RadzenTextBox @bind-Value="contact.Name" Name="Name" Style="width:100%" />
+                    <RadzenRequiredValidator Component="Name" Text="Name is required" Popup="true" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn Property="PhoneNumber" Title="Phone">
+                <Template Context="contact">
+                    @("+1" + contact.PhoneNumber)
+                </Template>
+                <EditTemplate Context="contact">
+                    <RadzenTextBox @bind-Value="contact.PhoneNumber" Name="Phone" Style="width:100%" InputAttributes="@(new Dictionary<string,object>{{"maxlength","10"},{"pattern","[0-9]*"},{"inputmode","numeric"}})" />
+                    <RadzenRegularExpressionValidator Component="Phone" Pattern="^[0-9]{10}$" Text="Phone must be 10 digits" Popup="true" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn Property="Notes" Title="Notes">
+                <EditTemplate Context="contact">
+                    <RadzenTextBox @bind-Value="contact.Notes" Style="width:100%" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn Context="contact" Filterable="false" Sortable="false" TextAlign="TextAlign.Right">
+                <Template Context="contact">
+                    <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light" Size="ButtonSize.Small" Click="@(() => EditRow(contact))" />
+                    <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.Small" Style="margin-left:5px" Click="@(() => DeleteRow(contact))" />
+                </Template>
+                <EditTemplate Context="contact">
+                    <RadzenButton Icon="check" ButtonStyle="ButtonStyle.Success" Size="ButtonSize.Small" Click="@(() => SaveRow(contact))" />
+                    <RadzenButton Icon="close" ButtonStyle="ButtonStyle.Light" Size="ButtonSize.Small" Style="margin-left:5px" Click="@(() => CancelEdit(contact))" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+        </Columns>
+    </RadzenDataGrid>
+}
+
+@code {
+    private string? userName;
+    private bool isLoaded;
+    private List<ContactModel> contacts = new();
+    RadzenDataGrid<ContactModel>? grid;
+    private bool isInserting;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            userName = await CookieHelper.LoginStatus();
+            if (string.IsNullOrEmpty(userName))
+            {
+                NavigationManager.NavigateTo("login?returnUrl=/contacts", true);
+            }
+            else
+            {
+                contacts = (await LoadContacts()).ToList();
+            }
+            isLoaded = true;
+            StateHasChanged();
+        }
+    }
+
+    async Task<IEnumerable<ContactModel>> LoadContacts()
+    {
+        var list = await MessageService.GetContacts();
+        return list.Select(c =>
+        {
+            c.PhoneNumber = c.PhoneNumber.StartsWith("+1") ? c.PhoneNumber.Substring(2) : c.PhoneNumber;
+            return c;
+        });
+    }
+
+    async Task InsertRow()
+    {
+        isInserting = true;
+        var contact = new ContactModel();
+        contacts.Add(contact);
+        await grid!.InsertRow(contact);
+    }
+
+    async Task EditRow(ContactModel contact)
+    {
+        await grid!.EditRow(contact);
+    }
+
+    void CancelEdit(ContactModel contact)
+    {
+        grid!.CancelEditRow(contact);
+        if (contact.Id == 0)
+        {
+            contacts.Remove(contact);
+        }
+        isInserting = false;
+    }
+
+    async Task SaveRow(ContactModel contact)
+    {
+        await grid!.UpdateRow(contact);
+        isInserting = false;
+    }
+
+    async Task DeleteRow(ContactModel contact)
+    {
+        bool? confirm = await DialogService.Confirm("Delete this contact?", "Confirm");
+        if (confirm == true)
+        {
+            if (contact.Id != 0)
+            {
+                await MessageService.DeleteContact(contact.Id);
+            }
+            contacts.Remove(contact);
+            await grid!.Reload();
+            NotificationService.Notify(NotificationSeverity.Success, "Contact deleted");
+        }
+    }
+
+    async Task OnUpdateRow(ContactModel contact)
+    {
+        await SaveContact(contact);
+    }
+
+    async Task OnCreateRow(ContactModel contact)
+    {
+        await SaveContact(contact);
+    }
+
+    async Task SaveContact(ContactModel contact)
+    {
+        try
+        {
+            var digits = new string((contact.PhoneNumber ?? string.Empty).Where(char.IsDigit).ToArray());
+            if (digits.Length != 10)
+            {
+                NotificationService.Notify(NotificationSeverity.Error, "Error", "Phone number must be 10 digits");
+                return;
+            }
+            var toSave = new ContactModel
+            {
+                Id = contact.Id,
+                Name = contact.Name,
+                PhoneNumber = digits,
+                Notes = contact.Notes
+            };
+            await MessageService.SaveContact(toSave);
+            contacts = (await LoadContacts()).ToList();
+            NotificationService.Notify(NotificationSeverity.Success, "Contact saved");
+        }
+        catch (Exception ex)
+        {
+            NotificationService.Notify(NotificationSeverity.Error, "Error", ex.Message);
+        }
+    }
+}

--- a/Client/Pages/Contacts.razor
+++ b/Client/Pages/Contacts.razor
@@ -33,7 +33,7 @@ else
                     @("+1" + contact.PhoneNumber)
                 </Template>
                 <EditTemplate Context="contact">
-                    <RadzenMask @bind-Value="contact.PhoneNumber" Name="Phone" Mask="(000) 000-0000" Style="width:100%" />
+                    <RadzenTextBox @bind-Value="contact.PhoneNumber" Name="Phone" Mask="(000) 000-0000" Style="width:100%" />
                     <RadzenRequiredValidator Component="Phone" Text="Phone is required" Popup="true" />
                 </EditTemplate>
             </RadzenDataGridColumn>

--- a/Client/Pages/Messages/Inbox.razor
+++ b/Client/Pages/Messages/Inbox.razor
@@ -1,0 +1,304 @@
+@page "/messages"
+@using Microsoft.AspNetCore.Components.Web
+@using Radzen
+@using System.Linq
+@using System.Timers
+@inject CookieHelper CookieHelper
+@inject NavigationManager NavigationManager
+@inject IMessageService MessageService
+@inject IJSRuntime JS
+@implements IDisposable
+
+<PageTitle>Messages</PageTitle>
+
+@if (!isLoaded)
+{
+    <p>Loading...</p>
+}
+else if (string.IsNullOrEmpty(userName))
+{
+    <div class="alert alert-warning">Please login to view messages.</div>
+}
+else
+{
+    <div class="chat-container">
+        <aside class="recipients">
+            <div class="new-chat" @onclick="StartNewChat"><span class="plus">+</span> New Message</div>
+            @foreach (var r in recipients)
+            {
+                var display = contacts.FirstOrDefault(c => c.PhoneNumber == r)?.Name ?? r;
+                var preview = lastMessages.ContainsKey(r) ? lastMessages[r] : string.Empty;
+                <div class="recipient @(r == selectedRecipient ? "active" : string.Empty)" @onclick="(() => LoadConversation(r))">
+                    <div class="avatar">@display.Substring(0,1)</div>
+                    <div class="info">
+                        <div class="name">@display</div>
+                        <div class="preview">@preview</div>
+                    </div>
+                </div>
+            }
+        </aside>
+        <section class="conversation">
+            @if (isNewChat)
+            {
+                <RadzenDropDown Data="@contacts" TextProperty="Name" ValueProperty="PhoneNumber"
+                                TValue="IEnumerable<string>" Value="@selectedRecipients" ValueChanged="@OnRecipientsChange" Multiple="true"
+                                AllowClear="true" Placeholder="Select recipients" Style="margin:10px; width:calc(100% - 20px);" />
+            }
+            <div class="messages" id="messages">
+                @foreach (var m in conversation)
+                {
+                    <div class="message-group @(m.Direction == "Sent" ? "outgoing" : "incoming")">
+                        <div class="timestamp">@m.Timestamp.ToLocalTime().ToString("g")</div>
+                        <div class="bubble @(m.Direction == "Sent" ? "outgoing" : "incoming")">@m.Body</div>
+                    </div>
+                }
+            </div>
+            <div class="input-bar">
+                <input id="messageInput" class="message-input" placeholder="Type a message" @bind="messageBody" @bind:event="oninput" @onkeydown="HandleKeyDown" />
+                <RadzenButton Icon="send" Click="@SendAsync" Disabled="@(!CanSend)" Style="margin-left:5px" />
+            </div>
+        </section>
+    </div>
+}
+
+<style>
+.chat-container {
+    display: flex;
+    height: 80vh;
+    border: 1px solid #ccc;
+}
+.recipients {
+    width: 30%;
+    border-right: 1px solid #ccc;
+    overflow-y: auto;
+    background: #333;
+}
+.new-chat {
+    padding: 10px;
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+    font-weight: bold;
+}
+.new-chat .plus {
+    margin-right: 6px;
+}
+.recipient {
+    padding: 10px;
+    display: flex;
+    cursor: pointer;
+    border-bottom: 1px solid #eee;
+    color: #fff;
+}
+.recipient.active {
+    background: #2a2a2a;
+}
+.avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: #007bff;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 10px;
+    font-weight: bold;
+}
+.info .name {
+    font-weight: bold;
+}
+.info .preview {
+    font-size: 0.85rem;
+    color: #ccc;
+}
+.conversation {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background: #222;
+}
+.messages {
+    flex: 1;
+    padding: 10px;
+    overflow-y: auto;
+}
+.message-group {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 8px;
+}
+.message-group.incoming {
+    align-items: flex-start;
+}
+.message-group.outgoing {
+    align-items: flex-end;
+}
+.timestamp {
+    font-size: 0.75rem;
+    color: #999;
+    margin-bottom: 2px;
+}
+.bubble {
+    max-width: 70%;
+    padding: 8px 12px;
+    border-radius: 12px;
+    white-space: pre-line;
+}
+.bubble.incoming {
+    background: #444;
+    color: #fff;
+}
+.bubble.outgoing {
+    background: #0b93f6;
+    color: #fff;
+}
+.input-bar {
+    display: flex;
+    border-top: 1px solid #ccc;
+    padding: 10px;
+}
+.message-input {
+    flex: 1;
+    border: none;
+    background: #222;
+    color: #fff;
+}
+.message-input:focus {
+    outline: none;
+}
+</style>
+
+@code {
+    private string? userName;
+    private bool isLoaded;
+    private List<string> recipients = new();
+    private List<MessageModel> conversation = new();
+    private string? selectedRecipient;
+    private List<string> selectedRecipients = new();
+    private string messageBody = string.Empty;
+    private List<ContactModel> contacts = new();
+    private Dictionary<string, string> lastMessages = new();
+    private bool isNewChat;
+    private Timer? refreshTimer;
+    private bool CanSend => selectedRecipients.Any() && !string.IsNullOrWhiteSpace(messageBody);
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            userName = await CookieHelper.LoginStatus();
+            if (string.IsNullOrEmpty(userName))
+            {
+                NavigationManager.NavigateTo("login?returnUrl=/messages", true);
+            }
+            else
+            {
+                contacts = (await MessageService.GetContacts()).ToList();
+                await RefreshAsync();
+                refreshTimer = new Timer(5000);
+                refreshTimer.Elapsed += async (_, __) => await InvokeAsync(RefreshAsync);
+                refreshTimer.AutoReset = true;
+                refreshTimer.Start();
+            }
+            isLoaded = true;
+            StateHasChanged();
+        }
+    }
+
+    private async Task LoadConversation(string recipient)
+    {
+        selectedRecipient = recipient;
+        selectedRecipients = new List<string> { recipient };
+        await RefreshAsync();
+        messageBody = string.Empty;
+        isNewChat = false;
+    }
+
+    private async Task OnRecipientsChange(IEnumerable<string> values)
+    {
+        selectedRecipients = values.ToList();
+        if (selectedRecipients.Count == 1)
+        {
+            await LoadConversation(selectedRecipients[0]);
+            isNewChat = false;
+        }
+        else
+        {
+            selectedRecipient = null;
+            conversation.Clear();
+        }
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && CanSend)
+        {
+            await SendAsync();
+        }
+    }
+
+    private async Task SendAsync()
+    {
+        var body = messageBody;
+        foreach (var recipient in selectedRecipients)
+        {
+            var msg = new MessageModel
+            {
+                Sender = userName!,
+                Recipient = recipient,
+                Body = body
+            };
+            await MessageService.SendMessage(msg);
+        }
+        messageBody = string.Empty;
+        await RefreshAsync();
+    }
+
+    private void StartNewChat()
+    {
+        isNewChat = true;
+        selectedRecipient = null;
+        selectedRecipients = new List<string>();
+        conversation.Clear();
+        messageBody = string.Empty;
+        _ = ScrollToBottomAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        if (string.IsNullOrEmpty(userName))
+            return;
+
+        var messages = (await MessageService.GetMessages(userName)).ToList();
+        recipients = messages
+            .Select(m => m.Sender == userName ? m.Recipient : m.Sender)
+            .Where(r => !string.IsNullOrEmpty(r))
+            .Distinct()
+            .ToList();
+
+        lastMessages.Clear();
+        foreach (var r in recipients)
+        {
+            var conv = messages
+                .Where(m => (m.Sender == userName && m.Recipient == r) || (m.Sender == r && m.Recipient == userName))
+                .OrderBy(m => m.Timestamp)
+                .ToList();
+            if (conv.Any())
+            {
+                lastMessages[r] = conv.Last().Body;
+                if (selectedRecipient == r)
+                    conversation = conv;
+            }
+        }
+
+        StateHasChanged();
+        await ScrollToBottomAsync();
+    }
+
+    public void Dispose()
+    {
+        refreshTimer?.Dispose();
+    }
+
+    private Task ScrollToBottomAsync() => JS.InvokeVoidAsync("scrollMessagesToBottom").AsTask();
+}

--- a/Client/Pages/Messages/Inbox.razor
+++ b/Client/Pages/Messages/Inbox.razor
@@ -54,7 +54,7 @@ else
                 }
             </div>
             <div class="input-bar">
-                <input id="messageInput" class="message-input" placeholder="Type a message" @bind="messageBody" @bind:event="oninput" @onkeydown="HandleKeyDown" />
+                <input id="messageInput" class="message-input" placeholder="Type a message (your name and department will be sent automatically)" @bind="messageBody" @bind:event="oninput" @onkeydown="HandleKeyDown" />
                 <RadzenButton Icon="send" Click="@SendAsync" Disabled="@(!CanSend)" Style="margin-left:5px" />
             </div>
         </section>
@@ -271,7 +271,7 @@ else
 
         var messages = (await MessageService.GetMessages(userName)).ToList();
         recipients = messages
-            .Select(m => m.Sender == userName ? m.Recipient : m.Sender)
+            .Select(m => m.Direction == "Sent" ? m.Recipient : m.Sender)
             .Where(r => !string.IsNullOrEmpty(r))
             .Distinct()
             .ToList();
@@ -280,7 +280,7 @@ else
         foreach (var r in recipients)
         {
             var conv = messages
-                .Where(m => (m.Sender == userName && m.Recipient == r) || (m.Sender == r && m.Recipient == userName))
+                .Where(m => (m.Recipient == r && m.Direction == "Sent") || (m.Sender == r && m.Direction != "Sent"))
                 .OrderBy(m => m.Timestamp)
                 .ToList();
             if (conv.Any())

--- a/Client/Pages/Messages/Inbox.razor
+++ b/Client/Pages/Messages/Inbox.razor
@@ -3,6 +3,7 @@
 @using Radzen
 @using System.Linq
 @using System.Timers
+@using System.Threading.Tasks
 @inject CookieHelper CookieHelper
 @inject NavigationManager NavigationManager
 @inject IMessageService MessageService
@@ -173,6 +174,7 @@ else
     private bool isLoaded;
     private List<string> recipients = new();
     private List<MessageModel> conversation = new();
+    private List<MessageModel> allMessages = new();
     private string? selectedRecipient;
     private List<string> selectedRecipients = new();
     private string messageBody = string.Empty;
@@ -193,8 +195,12 @@ else
             }
             else
             {
-                contacts = (await MessageService.GetContacts()).ToList();
-                await RefreshAsync();
+                var contactsTask = MessageService.GetContacts();
+                var messagesTask = MessageService.GetMessages(userName);
+                await Task.WhenAll(contactsTask, messagesTask);
+                contacts = contactsTask.Result.ToList();
+                ProcessMessages(messagesTask.Result.ToList());
+                await ScrollToBottomAsync();
                 refreshTimer = new Timer(5000);
                 refreshTimer.Elapsed += async (_, __) => await InvokeAsync(RefreshAsync);
                 refreshTimer.AutoReset = true;
@@ -270,6 +276,21 @@ else
             return;
 
         var messages = (await MessageService.GetMessages(userName)).ToList();
+        ProcessMessages(messages);
+        StateHasChanged();
+        await ScrollToBottomAsync();
+    }
+
+    public void Dispose()
+    {
+        refreshTimer?.Dispose();
+    }
+
+    private Task ScrollToBottomAsync() => JS.InvokeVoidAsync("scrollMessagesToBottom").AsTask();
+
+    private void ProcessMessages(List<MessageModel> messages)
+    {
+        allMessages = messages;
         recipients = messages
             .Select(m => m.Direction == "Sent" ? m.Recipient : m.Sender)
             .Where(r => !string.IsNullOrEmpty(r))
@@ -290,15 +311,5 @@ else
                     conversation = conv;
             }
         }
-
-        StateHasChanged();
-        await ScrollToBottomAsync();
     }
-
-    public void Dispose()
-    {
-        refreshTimer?.Dispose();
-    }
-
-    private Task ScrollToBottomAsync() => JS.InvokeVoidAsync("scrollMessagesToBottom").AsTask();
 }

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddScoped(sp =>
 
 
 builder.Services.AddScoped<IUserService, UserServiceProxy>();
+builder.Services.AddScoped<IMessageService, MessageServiceProxy>();
 
 builder.Services.AddScoped<CookieHelper>();
 

--- a/Client/Services/MessageServiceProxy.cs
+++ b/Client/Services/MessageServiceProxy.cs
@@ -1,0 +1,84 @@
+using NDAProcesses.Shared.Models;
+using NDAProcesses.Shared.Services;
+using System.Net.Http.Json;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NDAProcesses.Client.Services
+{
+    public class MessageServiceProxy : IMessageService
+    {
+        private readonly HttpClient _httpClient;
+
+        public MessageServiceProxy(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<IEnumerable<MessageModel>> GetMessages(string userName)
+        {
+            return await _httpClient.GetFromJsonAsync<IEnumerable<MessageModel>>($"api/messages/{userName}")
+                ?? Enumerable.Empty<MessageModel>();
+        }
+
+        public async Task<IEnumerable<MessageModel>> GetConversation(string userName, string recipient)
+        {
+            return await _httpClient.GetFromJsonAsync<IEnumerable<MessageModel>>($"api/messages/{userName}/conversation/{recipient}")
+                ?? Enumerable.Empty<MessageModel>();
+        }
+
+        public async Task<IEnumerable<string>> GetRecipients(string userName)
+        {
+            return await _httpClient.GetFromJsonAsync<IEnumerable<string>>($"api/messages/{userName}/recipients")
+                ?? Enumerable.Empty<string>();
+        }
+
+        public async Task SendMessage(MessageModel message)
+        {
+            await _httpClient.PostAsJsonAsync("api/messages", message);
+        }
+
+        public async Task<IEnumerable<ContactModel>> GetContacts()
+        {
+            return await _httpClient.GetFromJsonAsync<IEnumerable<ContactModel>>("api/messages/contacts")
+                ?? Enumerable.Empty<ContactModel>();
+        }
+
+        public async Task SaveContact(ContactModel contact)
+        {
+            var response = await _httpClient.PostAsJsonAsync("api/messages/contacts", contact);
+            if (!response.IsSuccessStatusCode)
+            {
+                var error = await response.Content.ReadAsStringAsync();
+                throw new ApplicationException(string.IsNullOrWhiteSpace(error) ? "Failed to save contact" : error);
+            }
+        }
+
+        public async Task DeleteContact(int id)
+        {
+            await _httpClient.DeleteAsync($"api/messages/contacts/{id}");
+        }
+
+        public async Task ScheduleMessage(ScheduledMessageModel message)
+        {
+            await _httpClient.PostAsJsonAsync("api/messages/schedule", message);
+        }
+
+        public async Task<IEnumerable<ScheduledMessageModel>> GetScheduledMessages(string userName)
+        {
+            return await _httpClient.GetFromJsonAsync<IEnumerable<ScheduledMessageModel>>($"api/messages/{userName}/scheduled")
+                ?? Enumerable.Empty<ScheduledMessageModel>();
+        }
+
+        public async Task CancelScheduledMessage(int id, string userName)
+        {
+            await _httpClient.DeleteAsync($"api/messages/{userName}/scheduled/{id}");
+        }
+
+        public Task SyncInbox()
+        {
+            // Inbox is automatically synced server-side
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/NdaProcesses.Shared/Models/ContactModel.cs
+++ b/NdaProcesses.Shared/Models/ContactModel.cs
@@ -1,0 +1,10 @@
+namespace NDAProcesses.Shared.Models
+{
+    public class ContactModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string PhoneNumber { get; set; } = string.Empty;
+        public string? Notes { get; set; }
+    }
+}

--- a/NdaProcesses.Shared/Models/MessageModel.cs
+++ b/NdaProcesses.Shared/Models/MessageModel.cs
@@ -1,0 +1,15 @@
+namespace NDAProcesses.Shared.Models
+{
+    public class MessageModel
+    {
+        public int Id { get; set; }
+        public string Sender { get; set; } = string.Empty;
+        public string Recipient { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+        public string Direction { get; set; } = string.Empty;
+        public string SenderName { get; set; } = string.Empty;
+        public string SenderDepartment { get; set; } = string.Empty;
+        public string ExternalId { get; set; } = string.Empty;
+    }
+}

--- a/NdaProcesses.Shared/Models/ScheduledMessageModel.cs
+++ b/NdaProcesses.Shared/Models/ScheduledMessageModel.cs
@@ -1,0 +1,14 @@
+namespace NDAProcesses.Shared.Models
+{
+    public class ScheduledMessageModel
+    {
+        public int Id { get; set; }
+        public string Sender { get; set; } = string.Empty;
+        public string SenderName { get; set; } = string.Empty;
+        public string SenderDepartment { get; set; } = string.Empty;
+        public string Recipient { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+        public DateTime ScheduledFor { get; set; }
+        public bool Sent { get; set; }
+    }
+}

--- a/NdaProcesses.Shared/Services/IMessageService.cs
+++ b/NdaProcesses.Shared/Services/IMessageService.cs
@@ -1,0 +1,19 @@
+using NDAProcesses.Shared.Models;
+
+namespace NDAProcesses.Shared.Services
+{
+    public interface IMessageService
+    {
+        Task<IEnumerable<MessageModel>> GetMessages(string userName);
+        Task<IEnumerable<MessageModel>> GetConversation(string userName, string recipient);
+        Task<IEnumerable<string>> GetRecipients(string userName);
+        Task SendMessage(MessageModel message);
+        Task<IEnumerable<ContactModel>> GetContacts();
+        Task SaveContact(ContactModel contact);
+        Task DeleteContact(int id);
+        Task ScheduleMessage(ScheduledMessageModel message);
+        Task<IEnumerable<ScheduledMessageModel>> GetScheduledMessages(string userName);
+        Task CancelScheduledMessage(int id, string userName);
+        Task SyncInbox();
+    }
+}

--- a/Server/Components/App.razor
+++ b/Server/Components/App.razor
@@ -20,6 +20,7 @@
     <script src="_content/Radzen.Blazor/Radzen.Blazor.js?v=@(typeof(Radzen.Colors).Assembly.GetName().Version)"></script>
     <script>navigator.serviceWorker.register('service-worker.js');</script>
     <script src="js/cookieHelper.js"></script>
+    <script src="js/chat.js"></script>
 
 </body>
 

--- a/Server/Controllers/MessagesController.cs
+++ b/Server/Controllers/MessagesController.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Mvc;
+using NDAProcesses.Shared.Models;
+using NDAProcesses.Shared.Services;
+using System;
+
+namespace NDAProcesses.Server.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class MessagesController : ControllerBase
+    {
+        private readonly IMessageService _messageService;
+
+        public MessagesController(IMessageService messageService)
+        {
+            _messageService = messageService;
+        }
+
+        [HttpGet("{userName}")]
+        public async Task<IEnumerable<MessageModel>> Get(string userName)
+        {
+            return await _messageService.GetMessages(userName);
+        }
+
+        [HttpGet("{userName}/conversation/{recipient}")]
+        public async Task<IEnumerable<MessageModel>> GetConversation(string userName, string recipient)
+        {
+            return await _messageService.GetConversation(userName, recipient);
+        }
+
+        [HttpGet("{userName}/recipients")]
+        public async Task<IEnumerable<string>> GetRecipients(string userName)
+        {
+            return await _messageService.GetRecipients(userName);
+        }
+
+        [HttpGet("contacts")]
+        public async Task<IEnumerable<ContactModel>> GetContacts()
+        {
+            return await _messageService.GetContacts();
+        }
+
+        [HttpPost("contacts")]
+        public async Task<IActionResult> SaveContact([FromBody] ContactModel contact)
+        {
+            try
+            {
+                await _messageService.SaveContact(contact);
+                return Ok();
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [HttpDelete("contacts/{id}")]
+        public async Task<IActionResult> DeleteContact(int id)
+        {
+            await _messageService.DeleteContact(id);
+            return Ok();
+        }
+
+        [HttpGet("{userName}/scheduled")]
+        public async Task<IEnumerable<ScheduledMessageModel>> GetScheduled(string userName)
+        {
+            return await _messageService.GetScheduledMessages(userName);
+        }
+
+        [HttpPost("schedule")]
+        public async Task<IActionResult> Schedule([FromBody] ScheduledMessageModel message)
+        {
+            await _messageService.ScheduleMessage(message);
+            return Ok();
+        }
+
+        [HttpDelete("{userName}/scheduled/{id}")]
+        public async Task<IActionResult> Cancel(string userName, int id)
+        {
+            await _messageService.CancelScheduledMessage(id, userName);
+            return Ok();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Post([FromBody] MessageModel message)
+        {
+            await _messageService.SendMessage(message);
+            return Ok();
+        }
+    }
+}

--- a/Server/Data/MessageContext.cs
+++ b/Server/Data/MessageContext.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using NDAProcesses.Shared.Models;
+
+namespace NDAProcesses.Server.Data
+{
+    public class MessageContext : DbContext
+    {
+        public MessageContext(DbContextOptions<MessageContext> options) : base(options)
+        {
+        }
+
+        public DbSet<MessageModel> Messages => Set<MessageModel>();
+        public DbSet<ContactModel> Contacts => Set<ContactModel>();
+        public DbSet<ScheduledMessageModel> ScheduledMessages => Set<ScheduledMessageModel>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<MessageModel>()
+                .HasIndex(m => m.ExternalId)
+                .IsUnique();
+        }
+    }
+}

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -4,6 +4,7 @@ using NDAProcesses.Client.Services;
 using NDAProcesses.Shared.Services;
 using NDAProcesses.Server.Services;
 using Microsoft.EntityFrameworkCore;
+using NDAProcesses.Server.Data;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -26,12 +27,28 @@ builder.Services.AddCors(options =>
 
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<CookieHelper>();
+builder.Services.AddScoped<IMessageService, MessageService>();
+builder.Services.AddHostedService<ScheduledMessageWorker>();
+builder.Services.AddHostedService<InboxPollerWorker>();
+builder.Services.AddSingleton<IFileLogger, FileLogger>();
+
+builder.Services.AddDbContext<MessageContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
 
 builder.Services.AddControllers();
 builder.Services.AddRadzenComponents();
 builder.Services.AddHttpClient();
 builder.Services.AddHttpContextAccessor();
 var app = builder.Build();
+
+var startupLogger = app.Services.GetRequiredService<IFileLogger>();
+startupLogger.System("Application starting");
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<MessageContext>();
+    db.Database.EnsureCreated();
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/Server/Services/FileLogger.cs
+++ b/Server/Services/FileLogger.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+
+namespace NDAProcesses.Server.Services
+{
+    public interface IFileLogger
+    {
+        void TextBee(string message);
+        void Sql(string message);
+        void System(string message);
+        void Fetch(string message);
+    }
+
+    public class FileLogger : IFileLogger
+    {
+        private readonly string _root;
+        public FileLogger(IWebHostEnvironment env)
+        {
+            _root = Path.Combine(env.ContentRootPath, "Logs");
+            Directory.CreateDirectory(_root);
+        }
+
+        private void Write(string fileName, string message)
+        {
+            var path = Path.Combine(_root, fileName);
+            var line = $"[{DateTime.UtcNow:o}] {message}{Environment.NewLine}";
+            File.AppendAllText(path, line);
+        }
+
+        public void TextBee(string message) => Write("textbee.log", message);
+        public void Sql(string message) => Write("sql.log", message);
+        public void System(string message) => Write("system.log", message);
+        public void Fetch(string message) => Write("fetch.log", message);
+    }
+}

--- a/Server/Services/InboxPollerWorker.cs
+++ b/Server/Services/InboxPollerWorker.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NDAProcesses.Shared.Services;
+using System;
+
+namespace NDAProcesses.Server.Services
+{
+    public class InboxPollerWorker : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<InboxPollerWorker> _logger;
+
+        public InboxPollerWorker(IServiceScopeFactory scopeFactory, ILogger<InboxPollerWorker> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var service = scope.ServiceProvider.GetRequiredService<IMessageService>();
+                    await service.SyncInbox();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error syncing inbox");
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+            }
+        }
+    }
+}

--- a/Server/Services/MessageService.cs
+++ b/Server/Services/MessageService.cs
@@ -1,0 +1,432 @@
+using System;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using NDAProcesses.Server.Data;
+using NDAProcesses.Shared.Models;
+using NDAProcesses.Shared.Services;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using System.Text;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace NDAProcesses.Server.Services
+{
+    public class MessageService : IMessageService
+    {
+        private readonly MessageContext _context;
+        private readonly HttpClient _httpClient;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<MessageService> _logger;
+        private readonly IUserService _userService;
+        private readonly IFileLogger _fileLogger;
+
+        public MessageService(MessageContext context, IHttpClientFactory httpClientFactory, IConfiguration configuration, ILogger<MessageService> logger, IUserService userService, IFileLogger fileLogger)
+        {
+            _context = context;
+            _httpClient = httpClientFactory.CreateClient();
+            _configuration = configuration;
+            _logger = logger;
+            _userService = userService;
+            _fileLogger = fileLogger;
+        }
+
+        public async Task<IEnumerable<MessageModel>> GetMessages(string userName)
+        {
+            await _context.Database.EnsureCreatedAsync();
+            await SyncInbox();
+
+            var sentRecipients = _context.Messages
+                .Where(m => m.Sender == userName)
+                .Select(m => m.Recipient);
+
+            return await _context.Messages
+                .Where(m => m.Sender == userName || (sentRecipients.Contains(m.Sender) && m.Direction != "Sent"))
+                .OrderBy(m => m.Timestamp)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<MessageModel>> GetConversation(string userName, string recipient)
+        {
+            await _context.Database.EnsureCreatedAsync();
+            await SyncInbox();
+
+            return await _context.Messages
+                .Where(m => (m.Sender == userName && m.Recipient == recipient) ||
+                            (m.Sender == recipient && m.Recipient == userName))
+                .OrderBy(m => m.Timestamp)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<string>> GetRecipients(string userName)
+        {
+            await _context.Database.EnsureCreatedAsync();
+            return await _context.Messages
+                .Where(m => m.Sender == userName || m.Recipient == userName)
+                .Select(m => m.Sender == userName ? m.Recipient : m.Sender)
+                .Distinct()
+                .ToListAsync();
+        }
+
+        public async Task SendMessage(MessageModel message)
+        {
+            await _context.Database.EnsureCreatedAsync();
+            var baseUrl = _configuration["TextBee:BaseUrl"];
+            var deviceId = _configuration["TextBee:DeviceId"];
+            var apiKey = _configuration["TextBee:ApiKey"];
+            var url = $"{baseUrl}/gateway/devices/{deviceId}/send-sms";
+            var user = await _userService.GetUserData(message.Sender);
+            message.SenderName = user?.DisplayName ?? string.Empty;
+            message.SenderDepartment = user?.Department ?? string.Empty;
+
+            message.Recipient = NormalizePhone(message.Recipient, strict: true);
+
+            var signature = ($"{message.SenderName}{(string.IsNullOrWhiteSpace(message.SenderDepartment) ? string.Empty : " - " + message.SenderDepartment)}").Trim();
+            if (!string.IsNullOrWhiteSpace(signature))
+            {
+                message.Body = $"{message.Body}\n\n{signature}";
+            }
+
+            var payload = new
+            {
+                recipients = new[] { message.Recipient },
+                message = message.Body
+            };
+
+            var json = JsonSerializer.Serialize(payload);
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+            request.Headers.Add("x-api-key", apiKey);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            _logger.LogInformation("Sending SMS via TextBee to {Recipient}", message.Recipient);
+            _fileLogger.TextBee($"Sending to {message.Recipient}: {message.Body}");
+            var response = await _httpClient.SendAsync(request);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("TextBee send failed: {Status} {Body}", response.StatusCode, responseBody);
+                _fileLogger.System($"TextBee send failed: {response.StatusCode} {responseBody}");
+                throw new HttpRequestException($"TextBee send failed: {response.StatusCode}");
+            }
+
+            _logger.LogInformation("TextBee send response: {Body}", responseBody);
+            _fileLogger.TextBee($"Response: {response.StatusCode} {responseBody}");
+
+            string? externalId = null;
+            try
+            {
+                using var doc = JsonDocument.Parse(responseBody);
+                externalId = GuessId(doc.RootElement);
+            }
+            catch
+            {
+                // ignore malformed JSON and fall back to a generated ID
+            }
+
+            message.ExternalId = string.IsNullOrWhiteSpace(externalId)
+                ? Guid.NewGuid().ToString()
+                : externalId;
+            message.Direction = "Sent";
+            message.Timestamp = DateTime.UtcNow;
+            _context.Messages.Add(message);
+            await _context.SaveChangesAsync();
+            _fileLogger.Sql($"Saved sent message {message.ExternalId} from {message.Sender} to {message.Recipient}");
+        }
+
+        public async Task<IEnumerable<ContactModel>> GetContacts()
+        {
+            await _context.Database.EnsureCreatedAsync();
+            return await _context.Contacts
+                .OrderBy(c => c.Name)
+                .ToListAsync();
+        }
+
+        public async Task SaveContact(ContactModel contact)
+        {
+            await _context.Database.EnsureCreatedAsync();
+            contact.PhoneNumber = NormalizePhone(contact.PhoneNumber, strict: true);
+            if (contact.Id == 0)
+            {
+                _context.Contacts.Add(contact);
+            }
+            else
+            {
+                _context.Contacts.Update(contact);
+            }
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteContact(int id)
+        {
+            await _context.Database.EnsureCreatedAsync();
+            var contact = await _context.Contacts.FirstOrDefaultAsync(c => c.Id == id);
+            if (contact != null)
+            {
+                _context.Contacts.Remove(contact);
+                await _context.SaveChangesAsync();
+            }
+        }
+
+        // Normalizes phone numbers to +1XXXXXXXXXX format. When strict is true the input must
+        // contain exactly 10 digits, allowing an optional leading 1 country code.
+        private static string NormalizePhone(string phone, bool strict = false)
+        {
+            if (string.IsNullOrWhiteSpace(phone))
+                return string.Empty;
+
+            var digits = new string(phone.Where(char.IsDigit).ToArray());
+
+            // Strip an optional leading 1 (country code) so both "6617420018" and
+            // "+16617420018" are accepted as the same number.
+            if (digits.Length == 11 && digits.StartsWith("1"))
+            {
+                digits = digits[1..];
+            }
+
+            if (strict && digits.Length != 10)
+            {
+                throw new ArgumentException("Phone number must be exactly 10 digits");
+            }
+
+            if (digits.Length != 10)
+            {
+                return string.Empty;
+            }
+
+            return "+1" + digits;
+        }
+
+        public async Task ScheduleMessage(ScheduledMessageModel message)
+        {
+            await _context.Database.EnsureCreatedAsync();
+            _context.ScheduledMessages.Add(message);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<IEnumerable<ScheduledMessageModel>> GetScheduledMessages(string userName)
+        {
+            await _context.Database.EnsureCreatedAsync();
+            return await _context.ScheduledMessages
+                .Where(m => m.Sender == userName && !m.Sent)
+                .OrderBy(m => m.ScheduledFor)
+                .ToListAsync();
+        }
+
+        public async Task CancelScheduledMessage(int id, string userName)
+        {
+            await _context.Database.EnsureCreatedAsync();
+            var msg = await _context.ScheduledMessages
+                .FirstOrDefaultAsync(m => m.Id == id && m.Sender == userName && !m.Sent);
+            if (msg != null)
+            {
+                _context.ScheduledMessages.Remove(msg);
+                await _context.SaveChangesAsync();
+            }
+        }
+
+        public async Task SyncInbox()
+        {
+            await _context.Database.EnsureCreatedAsync();
+
+            var baseUrl = _configuration["TextBee:BaseUrl"];
+            var deviceId = _configuration["TextBee:DeviceId"];
+            var apiKey = _configuration["TextBee:ApiKey"];
+
+            var receivedUrl = $"{baseUrl}/gateway/devices/{deviceId}/get-received-sms";
+            var allUrl = $"{baseUrl}/gateway/devices/{deviceId}/messages";
+            _fileLogger.TextBee($"Fetching inbox from {receivedUrl}");
+            var messages = await FetchMessages(receivedUrl, apiKey);
+            if (!messages.Any())
+            {
+                _fileLogger.TextBee("Received inbox empty, falling back to messages endpoint");
+                var all = await FetchMessages(allUrl, apiKey);
+                messages = all.Where(IsReceived);
+            }
+
+            var saved = 0;
+
+            foreach (var item in messages)
+            {
+                var sender = NormalizePhone(GetString(item, "from", "sender"));
+                var recipient = NormalizePhone(GetString(item, "to", "recipient"));
+                if (string.IsNullOrWhiteSpace(sender))
+                    continue;
+
+                var body = GetString(item, "message", "text", "body");
+                var tsString = GetString(item, "timestamp", "created_at");
+                var timestamp = DateTime.UtcNow;
+                if (!string.IsNullOrWhiteSpace(tsString))
+                    DateTime.TryParse(tsString, out timestamp);
+
+                var msgId = GuessId(item);
+                var externalId = string.IsNullOrWhiteSpace(msgId)
+                    ? ComputeHash(sender, recipient, body, timestamp)
+                    : msgId;
+
+                if (await _context.Messages.AnyAsync(m => m.ExternalId == externalId))
+                    continue;
+
+                // Map to the internal user who last sent to this number
+                var lastSent = await _context.Messages
+                    .Where(x => x.Recipient == sender && x.Direction == "Sent")
+                    .OrderByDescending(x => x.Timestamp)
+                    .FirstOrDefaultAsync();
+                if (lastSent != null)
+                    recipient = lastSent.Sender;
+                else if (string.IsNullOrWhiteSpace(recipient))
+                    recipient = string.Empty;
+
+                var message = new MessageModel
+                {
+                    Sender = sender,
+                    Recipient = recipient,
+                    Body = body,
+                    Direction = "Received",
+                    Timestamp = timestamp,
+                    ExternalId = externalId
+                };
+
+                _context.Messages.Add(message);
+                saved++;
+            }
+
+            if (saved > 0)
+            {
+                await _context.SaveChangesAsync();
+                _logger.LogInformation("Stored {Count} new incoming messages", saved);
+                _fileLogger.Sql($"Stored {saved} incoming messages");
+            }
+        }
+
+        private async Task<IEnumerable<JsonElement>> FetchMessages(string url, string apiKey)
+        {
+            try
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, url);
+                request.Headers.Add("x-api-key", apiKey);
+                request.Headers.Add("Accept", "application/json");
+
+                var response = await _httpClient.SendAsync(request);
+                var body = await response.Content.ReadAsStringAsync();
+                _fileLogger.TextBee($"Fetch {url} -> {(int)response.StatusCode} {response.StatusCode}");
+                _fileLogger.Fetch($"Fetch {url} -> {(int)response.StatusCode} {response.StatusCode}");
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogWarning("TextBee fetch {Url} failed: {Status} {Body}", url, response.StatusCode, body);
+                    _fileLogger.System($"TextBee fetch {url} failed: {(int)response.StatusCode} {response.StatusCode} {body}");
+                    _fileLogger.Fetch($"Fetch {url} failed: {(int)response.StatusCode} {response.StatusCode}");
+                    return Enumerable.Empty<JsonElement>();
+                }
+
+                if (string.IsNullOrWhiteSpace(body))
+                {
+                    _fileLogger.System($"TextBee fetch {url} returned empty body");
+                    _fileLogger.Fetch($"Fetch {url} returned empty body");
+                    return Enumerable.Empty<JsonElement>();
+                }
+
+                try
+                {
+                    using var doc = JsonDocument.Parse(body);
+                    var list = NormalizeMessages(doc.RootElement)
+                        .Select(e => e.Clone())
+                        .ToList();
+                    _fileLogger.TextBee($"Parsed {list.Count} messages from {url}");
+                    _fileLogger.Fetch($"Parsed {list.Count} messages from {url}");
+                    foreach (var msg in list)
+                    {
+                        var raw = msg.GetRawText().Replace("\n", " ").Replace("\r", " ");
+                        _fileLogger.Fetch($"Message {raw}");
+                    }
+                    return list;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "TextBee parse failure from {Url}", url);
+                    _fileLogger.System($"Parse failure from {url}: {ex.Message} Body: {body}");
+                    _fileLogger.Fetch($"Parse failure from {url}: {ex.Message}");
+                    return Enumerable.Empty<JsonElement>();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "TextBee fetch {Url} threw exception", url);
+                _fileLogger.System($"Fetch {url} threw {ex.GetType().Name}: {ex.Message}");
+                _fileLogger.Fetch($"Fetch {url} threw {ex.GetType().Name}: {ex.Message}");
+                return Enumerable.Empty<JsonElement>();
+            }
+        }
+
+        private static string? GuessId(JsonElement m)
+        {
+            foreach (var name in new[] { "id", "message_id", "_id", "uuid" })
+            {
+                if (m.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String)
+                {
+                    var v = prop.GetString();
+                    if (!string.IsNullOrWhiteSpace(v))
+                        return v;
+                }
+            }
+            return null;
+        }
+
+
+        private static string GetString(JsonElement m, params string[] names)
+        {
+            foreach (var n in names)
+            {
+                if (m.TryGetProperty(n, out var prop) && prop.ValueKind == JsonValueKind.String)
+                    return prop.GetString() ?? string.Empty;
+            }
+            return string.Empty;
+        }
+
+        private static bool IsReceived(JsonElement m)
+        {
+            var dir = GetString(m, "direction", "type").ToLowerInvariant();
+            return dir.Contains("recv") || dir == "inbound" || dir == "received";
+        }
+
+        private static string ComputeHash(string sender, string recipient, string body, DateTime timestamp)
+        {
+            var raw = $"{sender}|{recipient}|{body}|{timestamp:o}";
+            var bytes = Encoding.UTF8.GetBytes(raw);
+            var hash = SHA256.HashData(bytes);
+            return Convert.ToHexString(hash);
+        }
+
+        private static IEnumerable<JsonElement> NormalizeMessages(JsonElement root)
+        {
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in root.EnumerateArray())
+                    yield return item;
+                yield break;
+            }
+
+            if (root.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var key in new[] { "messages", "data", "results", "items" })
+                {
+                    if (root.TryGetProperty(key, out var arr) && arr.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var item in arr.EnumerateArray())
+                            yield return item;
+                        yield break;
+                    }
+                }
+
+                if (root.TryGetProperty("from", out _) || root.TryGetProperty("to", out _) ||
+                    root.TryGetProperty("message", out _) || root.TryGetProperty("text", out _) ||
+                    root.TryGetProperty("body", out _) || root.TryGetProperty("timestamp", out _) ||
+                    root.TryGetProperty("created_at", out _))
+                {
+                    yield return root;
+                }
+            }
+        }
+    }
+}

--- a/Server/Services/ScheduledMessageWorker.cs
+++ b/Server/Services/ScheduledMessageWorker.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NDAProcesses.Server.Data;
+using NDAProcesses.Shared.Models;
+using NDAProcesses.Shared.Services;
+using System;
+
+namespace NDAProcesses.Server.Services
+{
+    public class ScheduledMessageWorker : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<ScheduledMessageWorker> _logger;
+
+        public ScheduledMessageWorker(IServiceScopeFactory scopeFactory, ILogger<ScheduledMessageWorker> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var context = scope.ServiceProvider.GetRequiredService<MessageContext>();
+                    var service = scope.ServiceProvider.GetRequiredService<IMessageService>();
+
+                    var due = await context.ScheduledMessages
+                        .Where(m => !m.Sent && m.ScheduledFor <= DateTime.UtcNow)
+                        .ToListAsync(stoppingToken);
+
+                    foreach (var msg in due)
+                    {
+                        await service.SendMessage(new MessageModel
+                        {
+                            Sender = msg.Sender,
+                            SenderName = msg.SenderName,
+                            SenderDepartment = msg.SenderDepartment,
+                            Recipient = msg.Recipient,
+                            Body = msg.Body
+                        });
+                        msg.Sent = true;
+                    }
+
+                    if (due.Count > 0)
+                    {
+                        await context.SaveChangesAsync(stoppingToken);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error processing scheduled messages");
+                }
+
+                await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+            }
+        }
+    }
+}

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -4,6 +4,14 @@
     "UserName": "ldap_dev",
     "Password": "?57-BRAZIL-ITALY-neither-46?"
   },
+  "ConnectionStrings": {
+    "Default": "Server=10.201.50.70\\NDASHAFTDB;Initial Catalog=NDA_MS_FORM;User ID=sa;Password=NDA_Admin;TrustServerCertificate=True;"
+  },
+  "TextBee": {
+    "BaseUrl": "https://api.textbee.dev/api/v1",
+    "ApiKey": "f8a41718-e4c9-4567-b24c-eb9e33dd106d",
+    "DeviceId": "68bf24d3c3eec74784421f4c"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/Server/wwwroot/js/chat.js
+++ b/Server/wwwroot/js/chat.js
@@ -1,0 +1,6 @@
+window.scrollMessagesToBottom = () => {
+    const el = document.getElementById('messages');
+    if (el) {
+        el.scrollTop = el.scrollHeight;
+    }
+};


### PR DESCRIPTION
## Summary
- normalize 10-digit phone numbers with a +1 prefix so inbound TextBee messages map to existing conversations
- refresh the inbox every 5 seconds with a timer that reloads messages and updates the UI without a page refresh
- add inline contacts grid with optional notes and phone validation, persisting numbers with a +1 prefix
- auto-scroll conversations to the newest message and remove unsupported grid APIs
- validate contact numbers on save and surface API errors so invalid entries aren’t committed
- accept already-prefixed phone numbers when sending texts, stripping a leading 1 before enforcing 10 digits
- show contact numbers with a +1 prefix and enable filtering and sorting on the contacts grid
- darken the selected recipient and enable the send button while typing for better chat usability

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c15f9d059883299a2b81e38641d39f